### PR TITLE
FaultInjector: Add ARM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ebpfault --config /path/to/config.json --except-pid-list --pid_list pid1,pid2,pi
 * A recent Clang/LLVM installation (9.0 or better), compiled with BPF support
 * A recent libc++ or stdc++ library, supporting C++17
 * CMake >= 3.21.4. A pre-built binary can be downloaded from the [CMake's download page](https://cmake.org/download/).
-* Linux kernel >= 5.x (tested on Ubuntu 19.10) with the `CONFIG_BPF_KPROBE_OVERRIDE` option enabled
+* :warning: Linux kernel >= 5.x (tested on Ubuntu 19.10) with the `CONFIG_BPF_KPROBE_OVERRIDE` option enabled
 
 ### Building
 

--- a/src/faultinjector.cpp
+++ b/src/faultinjector.cpp
@@ -75,9 +75,18 @@ FaultInjector::FaultInjector(ebpf::PerfEventArray &perf_event_array,
     throw StringError::create("Fault configuration exceeds 100% probability");
   }
 
+  std::string arch;
+  #if __x86_64__
+    arch = "x64";
+  #elif __arm__ || __aarch64__
+    arch = "arm64";
+  #else
+    throw StringError::create("The current architecture is not valid. Supported: arm or x86_64.");
+  #endif
+
   // Create the event first, so we know whether the given system call exists or
   // not
-  auto syscall_name = "__x64_sys_" + d->config.name;
+  auto syscall_name = "__" + arch + "_sys_" + d->config.name;
 
   auto kprobe_event_exp =
       ebpf::IEvent::createKprobe(syscall_name, false, false);


### PR DESCRIPTION
## What does this PR do?

Fix issue: #16 

- `support arm architecture arm64`: The prefix of kernel functions is different across operating system. Exemple with the syscall sys_perf_event_open:

``` shell
# Linux lima-debian 5.10.160 aarch64 GNU/Linux
# bpftrace -l|grep arm64_sys|grep perf
kfunc:__arm64_sys_perf_event_open
```
``` shell
# Linux lima-debian 5.10.160 amd64 GNU/Linux
# bpftrace -l|grep arm64_sys|grep perf
kfunc:__x64_sys_perf_event_open
```

## Before fix

``` shell
# ebpfault --config config.yaml -p 1
Generating fault injectors...

 > openat
   Error list:
   -  50% => -ENOENT
Failed to create the enterKprobe event. Errno: 2
```

## After fix

``` shell
# ebpfault --config config.yaml -p 1
Generating fault injectors...

 > openat
   Error list:
   -  50% => -ENOENT

timestamp: 79479141991224 syscall: openat process_id: 1 thread_id: 1 injected_error: -ENOENT
       r15 ffff80001002beb0        r14 ffffb771225a4d10        r13 ffffb77122de1780 
       r12 ffffb77122db377c        rbp 0000000000000000        rbx 0000000000000000 
       r11 0000000000000000        r10 0000000000000000         r9 0000000000000000 
        r8 ffffb7712228a40c        rax 0000000000000000        rcx 0000000000000000 
       rdx 0000000000000000        rsi 0000000000000000        rdi 0000000000000000 
  orig_rax 0000000000000000        rip 0000000000000000         cs 0000000000000000 
    eflags 0000000000000000        rsp ffff80001002beb0         ss 0000000000000038 

```

## Testing

- [x] I manually tested the following steps:
    - [x] locally: ✅ with a `Linux lima-debian 5.10.160 aarch64 GNU/Linux` instance and it works properly after rebuild the linux kernel with the `CONFIG_BPF_KPROBE_OVERRIDE` option enabled.
    - [x] locally: ✅ with a `Linux lima-debian-amd64 5.10.0-19-amd64 Debian 5` instance and it works properly after rebuild the linux kernel with the `CONFIG_BPF_KPROBE_OVERRIDE` option enabled.
