### PR TITLE
Add grouped updates and schedule day to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Git submodules
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "submodules"
+    groups:
+      submodules:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add `groups` configuration to both `github-actions` and `gitsubmodule` ecosystems so Dependabot batches related updates into single PRs
- Set explicit `schedule.day: "monday"` for consistent weekly cadence

## Test plan
- [ ] Verify Dependabot creates grouped PRs on next scheduled run
- [ ] Confirm no existing open Dependabot PRs are disrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)